### PR TITLE
Update BasicEntityPersister.php

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -643,7 +643,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if ($newVal !== null) {
-                $newValId = $uow->getEntityIdentifier($newVal);
+                $newValId = $uow->getOriginalEntityData($newVal);
             }
 
             $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);


### PR DESCRIPTION
changed from getEntityIdentifier() to getEntityIdentifier() because previous options doesn't work with foreign keys which wasn't a primary key
